### PR TITLE
recompute posterior after beta update

### DIFF
--- a/altar/bayesian/COV.py
+++ b/altar/bayesian/COV.py
@@ -106,7 +106,7 @@ class COV(altar.component, family="altar.schedulers.cov", implements=scheduler):
         median = dataLikelihood.clone().sort().median()
 
         # compute {δβ} and the normalized {w}
-        β, self.cov = altar.libaltar.dbeta(self.minimizer, dataLikelihood.data, median, self.w.data)
+        β, self.cov = altar.libaltar.dbeta_grid(self.minimizer, dataLikelihood.data, median, self.w.data)
 
         # and return the new temperature
         return β
@@ -226,7 +226,7 @@ class COV(altar.component, family="altar.schedulers.cov", implements=scheduler):
         # no need to symmetrize it since it is symmetric by construction
         # NYI: check the eigenvalues to verify positive definiteness
 
-        # altar.libaltar.matrix_condition(Σ.data)
+        #altar.libaltar.matrix_condition(Σ.data, 0.001)
         # all done
         return Σ
 

--- a/altar/bayesian/COV.py
+++ b/altar/bayesian/COV.py
@@ -70,6 +70,7 @@ class COV(altar.component, family="altar.schedulers.cov", implements=scheduler):
         """
         Push {step} forward along the annealing schedule
         """
+
         # get the new temperature and store it
         β = self.updateTemperature(step=step)
         # compute the new parameter covariance matrix
@@ -83,7 +84,8 @@ class COV(altar.component, family="altar.schedulers.cov", implements=scheduler):
         step.sigma.copy(Σ)
         step.prior.copy(prior)
         step.data.copy(data)
-        step.posterior.copy(posterior)
+        # recompute posterior with updated beta
+        step.computePosterior()
 
         # and return it
         return step
@@ -223,6 +225,8 @@ class COV(altar.component, family="altar.schedulers.cov", implements=scheduler):
         """
         # no need to symmetrize it since it is symmetric by construction
         # NYI: check the eigenvalues to verify positive definiteness
+
+        # altar.libaltar.matrix_condition(Σ.data)
         # all done
         return Σ
 

--- a/altar/bayesian/CoolingStep.py
+++ b/altar/bayesian/CoolingStep.py
@@ -176,7 +176,7 @@ class CoolingStep:
 
         # print statistics (axis=0 average over samples)
         mean, sd = θ.mean_sd(axis=0)
-        channel.line(f"{indent}parameters (<40) (mean, sd):")
+        channel.line(f"{indent}parameters (mean, sd):")
         for i in range(min(40, parameters)):
             channel.line(f"{indent} ({mean[i]}, {sd[i]})")
 

--- a/altar/bayesian/Metropolis.py
+++ b/altar/bayesian/Metropolis.py
@@ -51,7 +51,7 @@ class Metropolis(altar.component, family="altar.samplers.metropolis", implements
         rng = application.rng.rng
         # set up the distribution for building the sample multiplicities; use a strictly
         # positive distribution to avoid generating candidates with zero displacement
-        self.uniform = altar.pdf.uniform_pos(support=(0,1), rng=rng)
+        self.uniform = altar.pdf.uniform_pos(rng=rng)
         # set up the distribution for the random walk displacement vectors
         self.uninormal = altar.pdf.ugaussian(rng=rng)
 

--- a/ext/altar.cc
+++ b/ext/altar.cc
@@ -17,6 +17,7 @@
 #include "exceptions.h"
 #include "metadata.h"
 #include "dbeta.h"
+#include "condition.h"
 
 
 // put everything in my private namespace
@@ -35,6 +36,10 @@ namespace altar {
             // annealing schedule
             { cov__name__, cov, METH_VARARGS, cov__doc__},
             { dbeta__name__, dbeta, METH_VARARGS, dbeta__doc__},
+            { dbeta_grid__name__, dbeta_grid, METH_VARARGS, dbeta_grid__doc__},
+
+            // matrix condition for positive definite
+            { matrix_condition__name__, matrix_condition, METH_VARARGS, matrix_condition__doc__},
 
             // sentinel
             {0, 0, 0, 0}

--- a/ext/condition.cc
+++ b/ext/condition.cc
@@ -1,0 +1,119 @@
+// -*- C++ -*-
+//
+// (c) 2013-2019 parasim inc
+// (c) 2010-2019 california institute of technology
+// all rights reserved
+//
+
+#include <portinfo>
+#include <Python.h>
+#include <cmath>
+#include <iostream>
+#include <iomanip>
+
+#include <gsl/gsl_sys.h>
+#include <gsl/gsl_min.h>
+#include <gsl/gsl_rng.h>
+#include <gsl/gsl_roots.h>
+#include <gsl/gsl_vector.h>
+#include <gsl/gsl_matrix.h>
+#include <gsl/gsl_randist.h>
+#include <gsl/gsl_statistics.h>
+#include <gsl/gsl_blas.h>
+#include <gsl/gsl_sort_vector.h>
+#include <gsl/gsl_eigen.h>
+
+#include <pyre/journal.h>
+#include <pyre/gsl/capsules.h>
+
+// local includes
+#include "condition.h"
+#include "capsules.h"
+
+// uniform distribution
+// uniform_sample
+const char * const altar::extensions::matrix_condition__name__ = "matrix_condition";
+const char * const altar::extensions::matrix_condition__doc__ =
+    "condition a matrix to be positive definite";
+
+PyObject *
+altar::extensions::matrix_condition(PyObject *, PyObject * args) {
+    // the arguments
+    PyObject * matrixCapsule;
+    double eval_ratio_min;
+    // build my debugging channel
+    pyre::journal::debug_t debug("altar.matrix_condition");
+
+    // unpack the argument tuple
+    int status = PyArg_ParseTuple(
+                                  args, "O!d:matrix_condition",
+                                  &PyCapsule_Type, &matrixCapsule,
+                                  &eval_ratio_min);
+    // if something went wrong
+    if (!status) return 0;
+    // bail out if the {matrix} capsule is not valid
+    if (!PyCapsule_IsValid(matrixCapsule, gsl::matrix::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, "invalid matrix capsule");
+        return 0;
+    }
+
+    // get the {sigma} matrix
+    gsl_matrix * sigma =
+        static_cast<gsl_matrix *>(PyCapsule_GetPointer(matrixCapsule, gsl::matrix::capsule_t));
+
+    // get matrix size
+    size_t m = sigma->size1;
+
+    // solve the eigen value problem
+    gsl_vector *eval = gsl_vector_alloc (m);
+    gsl_matrix *evec = gsl_matrix_alloc (m, m);
+    gsl_eigen_symmv_workspace * w = gsl_eigen_symmv_alloc (m);
+
+    gsl_eigen_symmv (sigma, eval, evec, w);
+    gsl_eigen_symmv_free (w);
+
+    // sort the eigen values in ascending order (magnitude)
+    gsl_eigen_symmv_sort (eval, evec,  GSL_EIGEN_SORT_ABS_ASC);
+
+    // make a transpose of the eigen vector matrix
+    gsl_matrix *evecT = gsl_matrix_alloc(m,m);
+    gsl_matrix_transpose_memcpy(evecT, evec);
+
+    // allocate a matrix for conditioned eigen values
+    gsl_matrix *diagM = gsl_matrix_calloc(m,m);
+
+    // set the minimum eigen value as the max * ratio
+    double eval_min = eval_ratio_min*gsl_vector_get(eval,m-1);
+    double eval_i;
+    // copy the eigenvalues, set it to eval_min if smaller
+    for (size_t i = 0; i < m; i++)
+    {
+        eval_i  = gsl_vector_get (eval, i);
+        if (eval_i<eval_min) gsl_matrix_set(diagM, i, i, eval_min);
+        else gsl_matrix_set(diagM, i, i, eval_i);
+    }
+
+    // reconstruct sigma from the conditioned eigen values
+    gsl_matrix *tmp = gsl_matrix_alloc(m,m);
+    gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, diagM, evecT, 0.0, tmp);
+    gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, evec, tmp, 0.0, sigma);
+
+    // make sigma symmetric
+    gsl_matrix_transpose_memcpy(tmp, sigma);
+    gsl_matrix_add(sigma,tmp);
+    gsl_matrix_scale(sigma, 0.5);
+
+    // free temporary data
+    gsl_vector_free (eval);
+    gsl_matrix_free (evec);
+    gsl_matrix_free (evecT);
+    gsl_matrix_free (diagM);
+    gsl_matrix_free (tmp);
+
+    // all done
+    // return None
+    Py_INCREF(Py_None);
+    return Py_None;
+}
+
+// end of file

--- a/ext/condition.h
+++ b/ext/condition.h
@@ -1,0 +1,24 @@
+// -*- C++ -*-
+//
+// (c) 2013-2019 parasim inc
+// (c) 2010-2019 california institute of technology
+// all rights reserved
+//
+
+#if !defined(altar_extensions_condition_h)
+#define altar_extensions_condition_h
+
+
+// place everything in my private namespace
+namespace altar {
+    namespace extensions {
+
+            extern const char * const matrix_condition__name__;
+            extern const char * const matrix_condition__doc__;
+            PyObject * matrix_condition(PyObject *, PyObject *);
+
+    } // of namespace extensions
+} // of namespace altar
+
+#endif //altar_extensions_condition_h
+// end of file

--- a/ext/dbeta.cc
+++ b/ext/dbeta.cc
@@ -95,6 +95,69 @@ altar::extensions::dbeta(PyObject *, PyObject * args) {
     return answer;
 }
 
+// dbeta
+const char * const altar::extensions::dbeta_grid__name__ = "dbeta_grid";
+const char * const altar::extensions::dbeta_grid__doc__ =
+    "compute the next increment to the annealing temperature";
+
+PyObject *
+altar::extensions::dbeta_grid(PyObject *, PyObject * args) {
+    // the arguments
+    PyObject * covCapsule;
+    PyObject * llkCapsule;
+    double llkMedian;
+    PyObject * wCapsule;
+
+    // build my debugging channel
+    pyre::journal::debug_t debug("altar.beta");
+
+    // unpack the argument tuple
+    int status = PyArg_ParseTuple(
+                                  args, "O!O!dO!:dbeta_grid",
+                                  &PyCapsule_Type, &covCapsule,
+                                  &PyCapsule_Type, &llkCapsule,
+                                  &llkMedian,
+                                  &PyCapsule_Type, &wCapsule
+                                  );
+    // if something went wrong
+    if (!status) return 0;
+    // bail out if the {cov} capsule is not valid
+    if (!PyCapsule_IsValid(covCapsule, altar::extensions::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, "invalid vector capsule for cov");
+        return 0;
+    }
+    // bail out if the {llk} capsule is not valid
+    if (!PyCapsule_IsValid(llkCapsule, altar::vector::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, "invalid vector capsule for llk");
+        return 0;
+    }
+    // bail out if the {w} capsule is not valid
+    if (!PyCapsule_IsValid(wCapsule, altar::vector::capsule_t)) {
+        PyErr_SetString(PyExc_TypeError, "invalid vector capsule for w");
+        return 0;
+    }
+
+    // get the {cov}
+    altar::bayesian::COV * cov =
+        static_cast<altar::bayesian::COV *>
+        (PyCapsule_GetPointer(covCapsule, altar::extensions::capsule_t));
+    // get the {w} vector
+    gsl_vector * w =
+        static_cast<gsl_vector *>(PyCapsule_GetPointer(wCapsule, altar::vector::capsule_t));
+    // get the {llk} vector
+    gsl_vector * llk =
+        static_cast<gsl_vector *>(PyCapsule_GetPointer(llkCapsule, altar::vector::capsule_t));
+
+    // update
+    cov->dbeta_grid(llk, llkMedian, w);
+
+    // build a tuple for the result
+    PyObject * answer = PyTuple_New(2);
+    PyTuple_SET_ITEM(answer, 0, PyFloat_FromDouble(cov->beta()));
+    PyTuple_SET_ITEM(answer, 1, PyFloat_FromDouble(cov->cov()));
+    // all done
+    return answer;
+}
 
 // dbeta
 const char * const altar::extensions::cov__name__ = "cov";

--- a/ext/dbeta.h
+++ b/ext/dbeta.h
@@ -25,6 +25,11 @@ namespace altar {
         extern const char * const dbeta__doc__;
         PyObject * dbeta(PyObject *, PyObject *);
 
+        // dbeta_gsl
+        extern const char * const dbeta_grid__name__;
+        extern const char * const dbeta_grid__doc__;
+        PyObject * dbeta_grid(PyObject *, PyObject *);
+
     } // of namespace extensions
 } // of namespace altar
 

--- a/lib/libaltar/bayesian/COV.cc
+++ b/lib/libaltar/bayesian/COV.cc
@@ -25,6 +25,7 @@
 #include <gsl/gsl_histogram.h>
 #include <gsl/gsl_statistics.h>
 #include <gsl/gsl_sort_vector.h>
+#include <gsl/gsl_eigen.h>
 
 #include <pyre/journal.h>
 
@@ -241,6 +242,119 @@ dbeta(vector_t *llk, double llkMedian, vector_t *w)
 }
 
 
+/// @par Main functionality
+/// Calculate the new annealing temperature by iterative grid-based searching
+/// @return The calculated beta value
+double
+altar::bayesian::COV::
+dbeta_grid(vector_t *llk, double llkMedian, vector_t *w)
+{
+    // build my debugging channel
+    pyre::journal::debug_t debug("altar.beta");
+
+    // turn off the err_handler
+    gsl_error_handler_t * gsl_hdl = gsl_set_error_handler_off ();
+
+    // consistency checks
+    assert(_betaMin == 0);
+    assert(_betaMax == 1);
+
+    // the beta search region
+    double beta_low = 0;
+    double beta_high = _betaMax - _beta;
+    double beta_guess = _betaMin + 5.0e-5;
+
+    assert(beta_high >= beta_low);
+    assert(beta_high >= beta_guess);
+    assert(beta_guess >= beta_low);
+
+    // allocate space for the parameters
+    cov::args covargs;
+    // attach the two vectors
+    covargs.w = w;
+    covargs.llk = llk;
+    // store our initial guess
+    covargs.dbeta = beta_guess;
+    // initialize the COV target
+    covargs.target = _target;
+    // initialize the median of the log-likelihoods
+    covargs.llkMedian = llkMedian;
+
+    // search bounds and initial guess
+    double f_beta_high = cov::cov(beta_high, &covargs);
+
+    // check whether we can skip straight to beta = 1
+    if (covargs.cov < _target || std::abs(covargs.cov-_target) < _tolerance) {
+        debug
+            << pyre::journal::at(__HERE__)
+            << " ** skipping to beta = " << _betaMax << " **"
+            << pyre::journal::endl;
+        // save my state
+        _beta = _betaMax;
+        _cov = covargs.cov;
+        // all done
+        return beta_high;
+    }
+
+    double f_beta_low = cov::cov(beta_low, &covargs);
+    // do this last so our first printout reflects the values at out guess
+    double f_beta_guess = cov::cov(beta_guess, &covargs);
+
+    // iterative grid searching
+    //double beta_grid_tolerance=1.E-6;
+    const int Nbeta=10;
+    int nbeta = 0;
+    double dbeta, beta_step;
+    int Nloop = 0;
+    if (debug) std::cout<<"dbeta minimization based on iterative grid searching:"<<std::endl;
+    bool Qfind = false;
+    do
+    {
+        ++Nloop;
+        beta_step = (beta_high-beta_low)/Nbeta;
+        int count=0;
+        for (beta_guess=beta_low, nbeta=0; nbeta<=Nbeta; beta_guess+=beta_step, ++nbeta)
+        {
+            f_beta_guess = cov::cov(beta_guess, &covargs);
+            if (std::abs(covargs.cov-_target) < _tolerance)
+            {
+                Qfind = true;
+                break;
+            }
+            if (covargs.cov >= _target)
+            {
+               if (nbeta==0) Qfind = true;
+               break;
+            }
+        }
+        if (nbeta>Nbeta) beta_guess -= beta_step;
+        if (debug){
+            std::cout
+                <<"      dbeta_low: "<<std::setw(11)<<std::setprecision(8)<<beta_low
+                <<"      dbeta_high: "<<std::setw(11)<<beta_high
+                <<"      dbeta_guess: "<<std::setw(11)<<beta_guess
+                <<"      cov: "<<std::setw(15)<<covargs.cov
+                << std::endl;
+        }
+        beta_high = beta_guess;
+        beta_low = beta_guess-beta_step;
+    }
+    while (Nloop<=Nbeta && !Qfind);
+
+    // assign dbeta
+    dbeta = beta_guess;
+
+    // make sure that we are left with the COV and weights evaluated for this guess
+    cov::cov(dbeta, &covargs);
+
+    // adjust my state
+    _cov = covargs.cov;
+    _beta += dbeta;
+    // return the beta update
+    return dbeta;
+}
+
+
 // meta-methods
 altar::bayesian::COV::
 ~COV()
@@ -308,10 +422,61 @@ computeCovariance(state_t & state, vector_t * weights) const
     return;
 }
 
+// condition the covariance matrix to ensure positive definiteness
+// i.e., replace eigenvalue with max(eigenvalue, maxEigenvalue*eval_ratio_min)
 void
 altar::bayesian::COV::
-conditionCovariance(matrix_t * sigma) const
+conditionCovariance(matrix_t * sigma, double eval_ratio_min) const
 {
+    // get matrix size
+    size_t m = sigma->size1;
+
+    // solve the eigen value problem
+    gsl_vector *eval = gsl_vector_alloc (m);
+    gsl_matrix *evec = gsl_matrix_alloc (m, m);
+    gsl_eigen_symmv_workspace * w = gsl_eigen_symmv_alloc (m);
+
+    gsl_eigen_symmv (sigma, eval, evec, w);
+    gsl_eigen_symmv_free (w);
+
+    // sort the eigen values in ascending order (magnitude)
+    gsl_eigen_symmv_sort (eval, evec,  GSL_EIGEN_SORT_ABS_ASC);
+
+    // make a transpose of the eigen vector matrix
+    gsl_matrix *evecT = gsl_matrix_alloc(m,m);
+    gsl_matrix_transpose_memcpy(evecT, evec);
+
+    // allocate a matrix for conditioned eigen values
+    gsl_matrix *diagM = gsl_matrix_calloc(m,m);
+
+    // set the minimum eigen value as the max * ratio
+    double eval_min = eval_ratio_min*gsl_vector_get(eval,m-1);
+    double eval_i;
+    // copy the eigenvalues, set it to eval_min if smaller
+    for (size_t i = 0; i < m; i++)
+    {
+        eval_i  = gsl_vector_get (eval, i);
+        if (eval_i<eval_min) gsl_matrix_set(diagM, i, i, eval_min);
+        else gsl_matrix_set(diagM, i, i, eval_i);
+    }
+
+    // reconstruct sigma from the conditioned eigen values
+    gsl_matrix *tmp = gsl_matrix_alloc(m,m);
+    gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, diagM, evecT, 0.0, tmp);
+    gsl_blas_dgemm(CblasNoTrans, CblasNoTrans, 1.0, evec, tmp, 0.0, sigma);
+
+    // make sigma symmetric
+    gsl_matrix_transpose_memcpy(tmp, sigma);
+    gsl_matrix_add(sigma,tmp);
+    gsl_matrix_scale(sigma, 0.5);
+
+    // free temporary data
+    gsl_vector_free (eval);
+    gsl_matrix_free (evec);
+    gsl_matrix_free (evecT);
+    gsl_matrix_free (diagM);
+    gsl_matrix_free (tmp);
+
     // all done
     return;
 }
@@ -441,18 +606,19 @@ double cov::cov(double dbeta, void * parameters)
 
     // compute the COV
     double mean = gsl_stats_mean(p.w->data, p.w->stride, p.w->size);
-    double sdev = gsl_stats_sd(p.w->data, p.w->stride, p.w->size);
+    double sdev = gsl_stats_sd_m(p.w->data, p.w->stride, p.w->size, mean);
     double cov = sdev / mean;
-    // store it
-    p.cov = cov;
+
 
     // if the COV is not well-defined
     if (gsl_isinf(cov) || gsl_isnan(cov)) {
         // set our metric to some big value
         p.metric = 1e100;
+        p.cov = 1e100;
     } else {
         // otherwise
         p.metric = gsl_pow_2(cov - p.target);
+        p.cov = cov;
     }
 
     // and return

--- a/lib/libaltar/bayesian/COV.h
+++ b/lib/libaltar/bayesian/COV.h
@@ -50,6 +50,7 @@ public:
     // lower level interface
 public:
     virtual double dbeta(vector_t * llk, double llkMedian, vector_t * w);
+    virtual double dbeta_grid(vector_t * llk, double llkMedian, vector_t * w);
 
     // meta-methods
 public:
@@ -62,7 +63,7 @@ public:
     // implementation details
 protected:
     void computeCovariance(state_t & state, vector_t * weights) const;
-    void conditionCovariance(matrix_t * sigma) const;
+    void conditionCovariance(matrix_t * sigma, double eval_ratio_min=0.001) const;
     void rankAndShuffle(state_t & state, vector_t * weights) const;
 
     // data

--- a/models/mogi/examples/mogi.pfg
+++ b/models/mogi/examples/mogi.pfg
@@ -31,6 +31,9 @@ mogi:
         ; the mogi engine: native or fast
         mode = fast
 
+        ; order of parameter sets
+        psets_list = [location, depth, source, offsets]
+
         ; parameter sets
         psets:
             location = contiguous

--- a/models/mogi/examples/synthetic/mogi.py
+++ b/models/mogi/examples/synthetic/mogi.py
@@ -34,7 +34,7 @@ class Mogi(altar.application, family="altar.applications.mogi"):
     d = altar.properties.float(default=3000)
     d.doc = "the depth of the Mogi source"
 
-    dV = altar.properties.float(default=10e10)
+    dV = altar.properties.float(default=1.e10)
     dV.doc = "the strength of the Mogi source"
 
     nu = altar.properties.float(default=.25)

--- a/models/mogi/mogi/Mogi.py
+++ b/models/mogi/mogi/Mogi.py
@@ -36,6 +36,10 @@ class Mogi(altar.models.bayesian, family="altar.models.mogi"):
     psets = altar.properties.dict(schema=altar.models.parameters())
     psets.doc = "the model parameter meta-data"
 
+    # order of parameters
+    psets_list = altar.properties.list(default=None)
+    psets_list.doc = "the list serving as the parameter orders"
+
     # data
     observations = altar.properties.int()
     observations.doc = "the number of model degrees of freedom"
@@ -231,11 +235,18 @@ class Mogi(altar.models.bayesian, family="altar.models.mogi"):
         psets = self.psets
         # initialize the offset
         offset = 0
-        # go through my parameter sets
-        for name, pset in psets.items():
-            # initialize the parameter set
-            offset += pset.initialize(model=self, offset=offset)
-        # the total number of parameters is now known, so record it
+        # check whether the order of parameters is provided/important
+        if self.psets_list is None: # not important
+            # go through my parameter sets
+            for name, pset in psets.items():
+                # initialize the parameter set
+                offset += pset.initialize(model=self, offset=offset)
+            # the total number of parameters is now known, so record it
+        else: # important, use psets_list as orders
+            for name in self.psets_list:
+                pset = psets[name]
+                offset += pset.initialize(model=self, offset=offset)
+        # record the total number of parameters
         self.parameters = offset
 
         # record the layout of the sample vector


### PR DESCRIPTION
This pull request consists of 
1. (COV.py) need to recompute posterior with new beta, instead of simply copying it back. 
2. (CoolingStep.py) Added (mean, std) report , also added hdf5 output support.